### PR TITLE
Propose to add a small clarification

### DIFF
--- a/liaison-coordinator-job-description.md
+++ b/liaison-coordinator-job-description.md
@@ -38,7 +38,8 @@ requests to the right liaison manager or to the entire IAB.
 
 ## Liaison Coordinator Tasks
 
-* Handling communication between the liaison managers and the rest of the IAB.
+* Handling communication between the liaison managers and the rest of the IAB
+  in order to provide support and advice, specialy when handling difficult situations.
 * Performing status checks with and gathering reports from the liaison
   managers. This level of effort depends on how active a particular
   liaison relationship is, which can vary widely depending on the


### PR DESCRIPTION
as this was particularly raised as a concern when I talked to one of the liaison manager recently. Or to put it different: it is important to make sure that the liaison mangers gets backing from someone on the IAB when needed. In former times apparently, if the liaison shepherd happened to be knowledgable about the organisation and issue at hand, this was sometimes done by the shepherd directly; however, I don't think it's the expectation that the liaison coordinators would care about all or any issues directly but rather bring it to the IAB and make sure that someone in the IAB (or if external if different expertise is needed) gets assigned and helps out.